### PR TITLE
Made tp modules comments

### DIFF
--- a/Modules/Teleportation/Checkpoint.cs
+++ b/Modules/Teleportation/Checkpoint.cs
@@ -1,4 +1,4 @@
-﻿using GorillaLocomotion;
+/*﻿using GorillaLocomotion;
 using Bark.Extensions;
 using Bark.Gestures;
 using Bark.GUI;
@@ -198,7 +198,7 @@ namespace Bark.Modules.Teleportation
 
         public override string Tutorial()
         {
-            return "Hold [Left Trigger] to spawn a checkpoint. Hold [Right Trigger] to return to it.";
+            return "Hold [Left Trigger] to spawn a checkpoint. Hold [Right Trigger] to return to it.";*/
         }
     }
 }

--- a/Modules/Teleportation/Checkpoint.cs
+++ b/Modules/Teleportation/Checkpoint.cs
@@ -198,7 +198,8 @@ namespace Bark.Modules.Teleportation
 
         public override string Tutorial()
         {
-            return "Hold [Left Trigger] to spawn a checkpoint. Hold [Right Trigger] to return to it.";*/
+            return "Hold [Left Trigger] to spawn a checkpoint. Hold [Right Trigger] to return to it.";
         }
     }
 }
+*/

--- a/Modules/Teleportation/Pearl.cs
+++ b/Modules/Teleportation/Pearl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+/*﻿using System;
 using UnityEngine;
 using Bark.Gestures;
 using Bark.GUI;
@@ -211,3 +211,4 @@ namespace Bark.Modules.Teleportation
         }
     }
 }
+*/

--- a/Modules/Teleportation/Portal.cs
+++ b/Modules/Teleportation/Portal.cs
@@ -1,4 +1,4 @@
-﻿using GorillaLocomotion;
+/*﻿using GorillaLocomotion;
 using Bark.Tools;
 using System;
 using UnityEngine;
@@ -318,3 +318,4 @@ namespace Bark.Modules.Teleportation
         }
     }
 }
+*/

--- a/Modules/Teleportation/Teleport.cs
+++ b/Modules/Teleportation/Teleport.cs
@@ -1,4 +1,4 @@
-﻿using GorillaLocomotion;
+/*﻿using GorillaLocomotion;
 using Bark.Extensions;
 using Bark.Gestures;
 using Bark.GUI;
@@ -173,3 +173,4 @@ namespace Bark.Modules
 
     }
 }
+*/


### PR DESCRIPTION
GorillaNot detects teleportation, and teleportation modules seem to be the main thing getting people banned. An alternative is making the player go to the "teleport position" super quickly instead of teleporting as GorillaNot doesn't detect changes in velocity.